### PR TITLE
Fix sidenav links in /documentation

### DIFF
--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -21,12 +21,12 @@
         <div class="span3 sidebar">
           <div data-spy="affix" data-offset-bottom="290">
             <ul class="nav nav-list sidenav">
-              <li><a href="#cloud_haskell_platform"><i class="icon-chevron-right"></i> Cloud Haskell Platform</a></li>
-              <li><a href="#network_transport_abstraction_layer"><i class="icon-chevron-right"></i> Network Abstraction Layer</a></li>
-              <li><a href="#concurrency_and_distribution"><i class="icon-chevron-right"></i> Concurrency and Distribution</a></li>
-              <li><a href="#what_is_serializable"><i class="icon-chevron-right"></i> What is Serializable</a></li>
-              <li><a href="#typed_channels"><i class="icon-chevron-right"></i> Typed Channels</a></li>
-              <li><a href="#rethinking_the_task_layer"><i class="icon-chevron-right"></i> Rethinking the Task Layer</a></li>
+              <li><a href="#cloud-haskell-platform"><i class="icon-chevron-right"></i> Cloud Haskell Platform</a></li>
+              <li><a href="#network-transport-abstraction_layer"><i class="icon-chevron-right"></i> Network Abstraction Layer</a></li>
+              <li><a href="#concurrency-and-distribution"><i class="icon-chevron-right"></i> Concurrency and Distribution</a></li>
+              <li><a href="#what-is-serializable"><i class="icon-chevron-right"></i> What is Serializable</a></li>
+              <li><a href="#typed-channels"><i class="icon-chevron-right"></i> Typed Channels</a></li>
+              <li><a href="#rethinking-the-task_layer"><i class="icon-chevron-right"></i> Rethinking the Task Layer</a></li>
            </ul>
           </div>
         </div>


### PR DESCRIPTION
Substitutes '_' with '-' in the links.