### PR TITLE
Remove references to the Jira issue tracker.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -22,7 +22,7 @@
         <ul class="footer-links">
           <li><a href="http://github.com/haskell-distributed/">Source</a></li>
           <li class="muted">&middot;</li>
-          <li><a href="https://cloud-haskell.atlassian.net">Issues</a></li>
+          <li><a href="https://github.com/haskell-distributed">Issues</a></li>
           <li class="muted">&middot;</li>
           <li><a href="/wiki.html">Wiki</a></li>
           <li class="muted">&middot;</li>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -35,7 +35,6 @@
                    <li><a href="/changes.html">ChangeLog</a></li>
                    <li><a href="http://www.haskell.org/haskellwiki/Cloud_Haskell">CH on haskell.org</a></li>
                    <li><a href="https://github.com/haskell-distributed">Github Repositories</a></li>
-                   <li><a href="https://cloud-haskell.atlassian.net/secure/BrowseProjects.jspa#all">Issue Tracker</a></li>
                    <li><a href="/static/semantics.pdf">Formal Semantics</a></li>
 		   <li><a href="http://dl.acm.org/citation.cfm?id=1863509.1863514&coll=DL&dl=GUIDE&CFID=462193996&CFTOKEN=19836659">Unified semantics for Future Erlang</a></li>
                    <li><a href="http://www.well-typed.com/blog/">Well-Typed Blog</a></li>

--- a/wiki/contributing.md
+++ b/wiki/contributing.md
@@ -52,11 +52,8 @@ All repositories must use the same git branch structure:
 ### __1. Check to see if your patch is likely to be accepted__
 
 We have a rather full backlog, so your help will be most welcome assisting
-us in clearing that. You can view the exiting open issues on the
-[jira issue tracker](https://cloud-haskell.atlassian.net/issues/?filter=10001).
-
-If you wish to submit a new issue there, you cannot do so without logging in
-creating an account (by providing your email address) and logging in.
+us in clearing that. You can view the exiting open issues on
+[github](https://github.com/haskell-distributed).
 
 It is also helpful to work out which component or sub-system should be
 changed. You may wish to email the maintainers to discuss this first.

--- a/wiki/faq.md
+++ b/wiki/faq.md
@@ -38,10 +38,7 @@ If the documentation doesn't answer your question, queries about Cloud Haskell
 can be directed to the Parallel Haskell Mailing List
 (parallel-haskell@googlegroups.com), which is pretty active. If you think
 you've found a bug, or would like to request a new feature, please visit the
-[Jira Issue Tracker](https://cloud-haskell.atlassian.net) and submit a bug.
-You **will** need to register with your email address to create new issues,
-though you can freely browse the existing tickets without doing so.
-
+[github](https://github.com/haskell-distributed) repositories and submit a bug.
 
 ### Getting Involved
 

--- a/wiki/maintainers.md
+++ b/wiki/maintainers.md
@@ -24,10 +24,10 @@ up though.
 
 #### Community
 
-We keep in touch through the [parallel-haskell google group][7], and once you've
+We keep in touch through the [parallel-haskell mailing list][5], and once you've
 joined the group, by posting to the mailing list address: parallel-haskell@googlegroups.com.
 This is a group for **all** things related to concurrent and parallel Haskell. There is
-also a maintainer/developer centric [cloud-haskell-developers google group][9], which is
+also a maintainer/developer centric [cloud-haskell-developers mailing list][6], which is
 more for in-depth questions about contributing to or maintaining Cloud Haskell.
 
 You might also find some of us hanging out at #haskell-distributed on
@@ -40,15 +40,14 @@ will be used to make announcements (of new releases, etc) on a regular basis.
 
 ### Bug/Issue Tracking and Continuous Integration
 
-Our bug tracker is a hosted/on-demand Jira, for which a free open source
-project license was kindly donated by [Atlassian][6]. You can browse all
-issues without logging in, however to report new issues/bugs you will
-need to provide an email address and create an account.
+We report issues for each project in [github][1].
+You can browse all issues without logging in, however to report new issues/bugs
+you will need to provide an email address and create an account.
 
 If you have any difficulties doing so, please post an email to the
-[parallel-haskell mailing list][7] at parallel-haskell@googlegroups.com.
+[parallel-haskell mailing list][5] at parallel-haskell@googlegroups.com.
 
-We currently use [travis-ci][11] for continuous integration. We do however,
+We currently use [travis-ci][7] for continuous integration. We do however,
 have an open source license for Atlassian Bamboo, which we will be migrating
 to over time - this process is quite involved so we don't have a picture of
 the timescales yet.
@@ -112,15 +111,6 @@ message.
 
 Once we migrate to Bamboo, this may change.
 
-#### Changing Jira bugs/issues via commit messages
-
-You can make complex changes to one or more Jira issues with a single commit message.
-As with skipping CI builds, please **do not** put this messy text into the first line
-of your commit messages.
-
-Details of the format/syntax required to do this can be found on
-[this Jira documentation page](https://confluence.atlassian.com/display/AOD/Processing+JIRA+issues+with+commit+messages)
-
 ----
 
 #### Follow the <a href="/wiki/contributing.html">Contributing guidelines</a>
@@ -171,9 +161,8 @@ Since moving to individual git repositories, the tagging scheme is now
 a branch named `release-x.y.z` and push both the newly created tag(s) and the
 branch(es).
 
-Once the release is out, you should go to [JIRA](https://cloud-haskell.atlassian.net)
-and close all the tickets for the release. Jira has a nice 'bulk change' feature
-that makes this very easy.
+Once the release is out, you should go to [github](https://github.com/haskell-distributed)
+and close all the tickets for the release.
 
 After that, it's time to tweet about the release, post to the parallel-haskell
 mailing list, blog etc. Spread the word.
@@ -182,10 +171,6 @@ mailing list, blog etc. Spread the word.
 [2]: https://github.com/haskell-distributed/haskell-distributed.github.com
 [3]: http://hackage.haskell.org
 [4]: http://git-scm.com/book/en/Git-Basics-Tagging
-[5]: https://cloud-haskell.atlassian.net/secure/Dashboard.jspa
-[6]: http://atlassian.com/
-[7]: https://groups.google.com/forum/?fromgroups=#!forum/parallel-haskell
-[8]: /team.html
-[9]: https://groups.google.com/forum/?fromgroups#!forum/cloud-haskell-developers
-[10]: http://en.wikipedia.org/wiki/Greenwich_Mean_Time
-[11]: https://travis-ci.org/
+[5]: https://groups.google.com/forum/?fromgroups=#!forum/parallel-haskell
+[6]: https://groups.google.com/forum/?fromgroups#!forum/cloud-haskell-developers
+[7]: https://travis-ci.org/

--- a/wiki/networktransport.md
+++ b/wiki/networktransport.md
@@ -38,7 +38,7 @@ completely stable yet. The design of the transport layer may also still change.
 Feedback and suggestions are most welcome. Email [Duncan](mailto:duncan@well-typed.com) or [Edsko](mailto:edsko@well-typed.com) at Well-Typed, find us at #haskell-distributed on
 Freenode, or post on the [Parallel Haskell][2] mailing list.
 
-You may also submit issues on the [JIRA issue tracker][8].
+You may also submit issues on [github][8].
 
 ### Hello World
 
@@ -383,10 +383,9 @@ send to it, we don't allocate any unneeded resources).
 
 [1]: http://www.olcf.ornl.gov/center-projects/common-communication-interface/
 [2]: https://groups.google.com/forum/?fromgroups#!forum/parallel-haskell
-[3]: http://cloud-haskell.atlassian.net
 [4]: /tutorials/2.nt_tutorial.html
 [5]: /wiki/newtransports.html
 [6]: /wiki/newdesign.html
 [7]: /wiki/protocols.html
-[8]: https://cloud-haskell.atlassian.net/issues/?filter=10002
+[8]: https://github.com/haskell-distributed
 [9]: http://lists.freebsd.org/pipermail/freebsd-hackers/2009-March/028006.html "2 uni-directional TCP connection good?"


### PR DESCRIPTION
Issues are handled now in the github issue tracker of each repository.