### PR TITLE
remove references to Jira from the wiki

### DIFF
--- a/wiki/faq.md
+++ b/wiki/faq.md
@@ -19,19 +19,6 @@ there are still gaps.
 
 You can find them via the *resources* tab just above this page.
 
-#### Will I have to register a Jira account to submit issues?
-
-Yes, you will need to provide a name and email address.
-
-#### Why are you using Jira instead of Github Issues? It seems more complicated.
-
-Jira **is** a bit more complicated than github's bug tracker, and it's certainly
-not perfect. It is, however, a lot better suited to managing and planning a
-project of this size. Cloud Haskell consists of no less than **13** individual
-projects at this time, and that's not to mention some of the experimental ones
-that have been developed by community members and *might* end up being absorbed
-by the team.
-
 ### Help
 
 If the documentation doesn't answer your question, queries about Cloud Haskell

--- a/wiki/maintainers.md
+++ b/wiki/maintainers.md
@@ -11,7 +11,7 @@ process and in particular, the branching strategy. We also point out Cloud Haske
 various bits of infrastructure as they stand at the moment.
 
 Perhaps the most important thing to do as a maintainer, is to make other developers
-aware of what you're working on by assigning the Jira issue to yourself!
+aware of what you're working on by assigning the github issue to yourself!
 
 ----
 #### Releases
@@ -132,7 +132,7 @@ you've finished and uploaded the release. If you build and tag three projects,
 only to find that a subsequent dependent package needs a bit of last minute
 surgery, you'll be sorry you didn't wait. With that in mind....
 
-Before releasing any source code, make sure that all the jira tickets
+Before releasing any source code, make sure that all the github tickets
 added to the release are either resolved or remove them from the
 release if you've decided to exclude them.
 


### PR DESCRIPTION
according to 3b49b2465cb28ce9877c250c7e64b3795292e93c, issues are
now handled in the github issue tracker of each repository, so those
bits were outdated.