### PR TITLE
Fix links to archived github projects

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,13 +4,13 @@ title: Home
 ---
 Cloud Haskell: Erlang-style concurrent and distributed programming in Haskell.
 The Cloud Haskell Platform consists of a
-[generic network transport API](https://github.com/haskell-distributed/network-transport),
-libraries for sending [static closures](https://github.com/haskell-distributed/distributed-static) to remote nodes, a rich [API for distributed programming](https://github.com/haskell-distributed/distributed-process) and a
+[generic network transport API](https://github.com/haskell-distributed/distributed-process/tree/master/packages/network-transport),
+libraries for sending [static closures](https://github.com/haskell-distributed/distributed-process/tree/master/packages/distributed-static) to remote nodes, a rich [API for distributed programming](https://github.com/haskell-distributed/distributed-process/tree/master/packages/distributed-process) and a
 set of platform libraries modelled after Erlang's [Open Telecom Platform](http://www.erlang.org/doc/).
 
 Generic network transport backends have been developed for
-[TCP](https://github.com/haskell-distributed/network-transport-tcp) and
-[in-memory](https://github.com/haskell-distributed/network-transport-inmemory)
+[TCP](https://github.com/haskell-distributed/distributed-process/tree/master/packages/network-transport-tcp) and
+[in-memory](https://github.com/haskell-distributed/distributed-process/tree/master/packages/network-transport-inmemory)
 messaging, and several other implementations are available including a transport for
 [Windows Azure](https://github.com/haskell-distributed/distributed-process-azure). The [wiki](/wiki.html) provides links to a number of resources for learning about the conceptual underpinnings of Cloud Haskell, and some [examples](https://github.com/haskell-distributed/distributed-process-demos).
 


### PR DESCRIPTION
Links now point to the monorepo location for these projects, though I'm unsure it's the best place to link with them not having READMEs.